### PR TITLE
do not set defaults for gas limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.0.10]
+
+### Changed
+- `callGasLimit`, `verificationGasLimit`, `preVerificationGas` fields are now nullable
+and there aren't any defaults provided for them in the `defaultUserOp` constructor of
+`IUserOperation` class.
+- You can specify default values for `callGasLimit`, `verificationGasLimit`,
+`preVerificationGas` while initializing the `EtherspotWallet`.
+
 ## [0.0.9]
 
 ### Changed

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -63,17 +63,17 @@ class UserOperationBuilder implements IUserOperationBuilder {
   }
 
   @override
-  BigInt getCallGasLimit() {
+  BigInt? getCallGasLimit() {
     return _currentOp.callGasLimit;
   }
 
   @override
-  BigInt getVerificationGasLimit() {
+  BigInt? getVerificationGasLimit() {
     return _currentOp.verificationGasLimit;
   }
 
   @override
-  BigInt getPreVerificationGas() {
+  BigInt? getPreVerificationGas() {
     return _currentOp.preVerificationGas;
   }
 

--- a/lib/src/constants/defaults.dart
+++ b/lib/src/constants/defaults.dart
@@ -1,0 +1,3 @@
+class Defaults {
+  static final defaultVerificationGasLimit = BigInt.from(70000);
+}

--- a/lib/src/preset/builder/etherspot_wallet.dart
+++ b/lib/src/preset/builder/etherspot_wallet.dart
@@ -111,16 +111,20 @@ class EtherspotWallet extends UserOperationBuilder {
       );
     }
 
+    final defaults = {
+      'sender': instance.proxy.self.address.toString(),
+      'signature': bytesToHex(
+        credentials.signPersonalMessageToUint8List(
+          Uint8List.fromList('0xdead'.codeUnits),
+        ),
+        include0x: true,
+      ),
+    };
+
+    _setDefaultGasLimitsIfProvided(opts, defaults);
+
     final baseInstance = instance
-        .useDefaults({
-          'sender': instance.proxy.self.address.toString(),
-          'signature': bytesToHex(
-            credentials.signPersonalMessageToUint8List(
-              Uint8List.fromList('0xdead'.codeUnits),
-            ),
-            include0x: true,
-          ),
-        })
+        .useDefaults(defaults)
         .useMiddleware(instance.resolveAccount)
         .useMiddleware(getGasPrice(
           instance.etherspotWalletFactory.client,
@@ -139,6 +143,21 @@ class EtherspotWallet extends UserOperationBuilder {
 
     return withPM.useMiddleware(eOASignature(instance.credentials))
         as EtherspotWallet;
+  }
+
+  static void _setDefaultGasLimitsIfProvided(
+    IPresetBuilderOpts? opts,
+    Map<String, dynamic> defaults,
+  ) {
+    final gasLimitOptions = opts?.gasLimitOptions;
+
+    final callGasLimit = gasLimitOptions?.callGasLimit;
+    final verificationGasLimit = gasLimitOptions?.verificationGasLimit;
+    final preVerificationGas = gasLimitOptions?.preVerificationGas;
+
+    defaults["callGasLimit"] = callGasLimit;
+    defaults["verificationGasLimit"] = verificationGasLimit;
+    defaults["preVerificationGas"] = preVerificationGas;
   }
 
   /// Executes a transaction on the network.

--- a/lib/src/preset/middleware/gas_limit.dart
+++ b/lib/src/preset/middleware/gas_limit.dart
@@ -1,3 +1,4 @@
+import 'package:userop/src/constants/defaults.dart';
 import 'package:userop/src/types.dart';
 import 'package:web3dart/crypto.dart';
 import 'package:web3dart/json_rpc.dart';
@@ -24,11 +25,10 @@ UserOperationMiddlewareFn estimateUserOperationGas(
 ) {
   return (ctx) async {
     if (ctx.op.nonce.compareTo(BigInt.zero) == 0) {
-      ctx.op.verificationGasLimit = ctx.op.verificationGasLimit +
-          await estimateCreationGas(
-            client,
-            ctx.op.initCode,
-          );
+      final currentVerificationGasLimit =
+          ctx.op.verificationGasLimit ?? Defaults.defaultVerificationGasLimit;
+      ctx.op.verificationGasLimit = currentVerificationGasLimit +
+          await estimateCreationGas(client, ctx.op.initCode);
     }
 
     final rpcResponse = await provider.call(

--- a/lib/src/preset/middleware/paymaster.dart
+++ b/lib/src/preset/middleware/paymaster.dart
@@ -1,4 +1,5 @@
 import 'package:http/http.dart';
+import 'package:userop/src/constants/defaults.dart';
 import 'package:userop/userop.dart' hide Client;
 
 import '../../models/verifying_paymaster_result.dart';
@@ -8,7 +9,9 @@ UserOperationMiddlewareFn verifyingPaymaster(
   Map<String, dynamic> context,
 ) {
   return (ctx) async {
-    ctx.op.verificationGasLimit = ctx.op.verificationGasLimit * BigInt.from(3);
+    final baseVerificationGasLimit =
+        ctx.op.verificationGasLimit ?? Defaults.defaultVerificationGasLimit;
+    ctx.op.verificationGasLimit = baseVerificationGasLimit * BigInt.from(3);
 
     final provider = BundlerJsonRpcProvider(paymasterRpc, Client());
     final rpcResponse = await provider.call(

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -18,13 +18,13 @@ class IUserOperation {
   late String callData;
 
   /// The gas limit for the operation call.
-  late BigInt callGasLimit;
+  late BigInt? callGasLimit;
 
   /// The gas limit for operation verification.
-  late BigInt verificationGasLimit;
+  late BigInt? verificationGasLimit;
 
   /// The gas for pre-verification of the operation.
-  late BigInt preVerificationGas;
+  late BigInt? preVerificationGas;
 
   /// The maximum fee per gas for the operation.
   late BigInt maxFeePerGas;
@@ -45,9 +45,6 @@ class IUserOperation {
         nonce: BigInt.zero,
         initCode: '0x',
         callData: '0x',
-        callGasLimit: BigInt.from(35000),
-        verificationGasLimit: BigInt.from(70000),
-        preVerificationGas: BigInt.from(21000),
         maxFeePerGas: BigInt.zero,
         maxPriorityFeePerGas: BigInt.zero,
         paymasterAndData: '0x',
@@ -81,9 +78,9 @@ class IUserOperation {
     required this.nonce,
     required this.initCode,
     required this.callData,
-    required this.callGasLimit,
-    required this.verificationGasLimit,
-    required this.preVerificationGas,
+    this.callGasLimit,
+    this.verificationGasLimit,
+    this.preVerificationGas,
     required this.maxFeePerGas,
     required this.maxPriorityFeePerGas,
     required this.paymasterAndData,
@@ -140,13 +137,13 @@ abstract class IUserOperationBuilder {
   String getCallData();
 
   /// Gets the call gas limit of the operation.
-  BigInt getCallGasLimit();
+  BigInt? getCallGasLimit();
 
   /// Gets the verification gas limit of the operation.
-  BigInt getVerificationGasLimit();
+  BigInt? getVerificationGasLimit();
 
   /// Gets the pre-verification gas of the operation.
-  BigInt getPreVerificationGas();
+  BigInt? getPreVerificationGas();
 
   /// Gets the max fee per gas of the operation.
   BigInt getMaxFeePerGas();

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -280,12 +280,35 @@ class IPresetBuilderOpts {
   EthereumAddress? factoryAddress;
   UserOperationMiddlewareFn? paymasterMiddleware;
   String? overrideBundlerRpc;
+  GasLimitOptions? gasLimitOptions;
+
+  IPresetBuilderOpts({
+    this.entryPoint,
+    this.salt,
+    this.factoryAddress,
+    this.paymasterMiddleware,
+    this.overrideBundlerRpc,
+    this.gasLimitOptions,
+  });
+}
+
+class GasLimitOptions {
+  final BigInt? callGasLimit;
+  final BigInt? verificationGasLimit;
+  final BigInt? preVerificationGas;
+
+  const GasLimitOptions({
+    this.callGasLimit,
+    this.verificationGasLimit,
+    this.preVerificationGas,
+  });
 }
 
 class Call {
   EthereumAddress to;
   BigInt value;
   Uint8List data;
+
   Call({
     required this.to,
     required this.value,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: userop
 description: A lightweight Dart library for quickly and easily building ERC-4337
   UserOperations.
-version: 0.0.9
+version: 0.0.10
 repository: https://github.com/fuseio/userop.dart
 
 environment:


### PR DESCRIPTION
- remove fields related to gas limits from defaults and make these fields nullable
- add a default verficiationGasLimit
- if verificationGasLimit is null, use the default value in estimateUserOperationGas middleware
- if verificationGasLimit is null, use the default value
- Accept gas limits as options when initializing EtherspotWallet
