### PR TITLE
Hotfix/eip1559 gas price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.1.7]
+
+### Fixed
+- Retrieving the gas price for chains compatible with EIP-1559.
+
+### Changed
+- The condition to skip the `getGasPrice` middleware when both `maxFeePerGas` and `maxPriorityFeePerGas` are specified has been removed.
+
 ## [0.1.6]
 
 ### Fixed

--- a/lib/src/models/gas_estimate.freezed.dart
+++ b/lib/src/models/gas_estimate.freezed.dart
@@ -12,7 +12,7 @@ part of 'gas_estimate.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 GasEstimate _$GasEstimateFromJson(Map<String, dynamic> json) {
   return _GasEstimate.fromJson(json);

--- a/lib/src/models/verifying_paymaster_result.freezed.dart
+++ b/lib/src/models/verifying_paymaster_result.freezed.dart
@@ -12,7 +12,7 @@ part of 'verifying_paymaster_result.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 VerifyingPaymasterResult _$VerifyingPaymasterResultFromJson(
     Map<String, dynamic> json) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: userop
 description: A lightweight Dart library for quickly and easily building ERC-4337
   UserOperations.
-version: 0.1.6
+version: 0.1.7
 repository: https://github.com/fuseio/userop.dart
 
 environment:
@@ -10,14 +10,14 @@ environment:
 dependencies:
   eth_sig_util: ^0.0.9
   freezed_annotation: ^2.4.1
-  http: ^1.1.2
+  http: ^1.2.1
   json_annotation: ^4.8.1
   web3dart: ^2.7.2
 
 dev_dependencies:
   build_runner: ^2.4.8
-  freezed: ^2.4.6
+  freezed: ^2.4.7
   json_serializable: ^6.7.1
   lints: ^3.0.0
-  test: ^1.25.1
+  test: ^1.25.2
   web3dart_builders: ^0.0.7


### PR DESCRIPTION
### Fixed
- Retrieving the gas price for chains compatible with EIP-1559.

### Changed
- The condition to skip the `getGasPrice` middleware when both `maxFeePerGas` and `maxPriorityFeePerGas` are specified has been removed.
